### PR TITLE
Support Nuke 11.x

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "libwebp",
-        "repositoryURL": "https://github.com/SDWebImage/libwebp-Xcode",
-        "state": {
-          "branch": null,
-          "revision": "2b3b43faaef54d1b897482428428357b7f7cd08b",
-          "version": "1.2.1"
-        }
-      },
-      {
-        "package": "Nuke",
-        "repositoryURL": "https://github.com/kean/Nuke.git",
-        "state": {
-          "branch": null,
-          "revision": "958ca90df22fc77fdf33b5b9a6d70102b7743851",
-          "version": "10.9.0"
-        }
+  "pins" : [
+    {
+      "identity" : "libwebp-xcode",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/libwebp-Xcode",
+      "state" : {
+        "revision" : "2b3b43faaef54d1b897482428428357b7f7cd08b",
+        "version" : "1.2.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke.git",
+      "state" : {
+        "revision" : "9df754fe4ca4c5abdf3376e4e9ec33b3485bf180",
+        "version" : "11.2.1"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,14 @@
-// swift-tools-version: 5.4
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 5.7
 
 import PackageDescription
 
 let package = Package(
     name: "NukeWebP",
     platforms: [
-        .macOS(.v10_13),
-        .iOS(.v11),
-        .tvOS(.v11),
-        .watchOS(.v4)
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(
@@ -21,10 +20,9 @@ let package = Package(
         .library(
             name: "NukeWebPAdvanced",
             targets: ["NukeWebPAdvanced"]),
-        
     ],
     dependencies: [
-        .package(url: "https://github.com/kean/Nuke.git", from: "10.9.0"),
+        .package(url: "https://github.com/kean/Nuke.git", from: "11.2.1"),
         .package(url: "https://github.com/SDWebImage/libwebp-Xcode", from: "1.2.1"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ WebPImageDecoder.enable(closure: {
 
 | Swift | Xcode | iOS | macOS | tvOS | watchOS |
 |:-----:|:-----:|:---:|:-----:|:----:|:-------:|
-| 5.4 | 13.0 | 11.0 | 10.13 | 11.0 | 4.0 |
+| 5.6 | 13.3 | 13.0 | 10.15 | 13.0 | 6.0 |
 
 ## Dependencies
 | [Nuke](https://github.com/kean/Nuke) | [libwebp](https://github.com/SDWebImage/libwebp-Xcode) |
 |:---:|:---:|
-| >= 10.9.0 | >=v1.2.1 |
+| >= 11.2.1 | >=v1.2.1 |
 
 ## Author
 

--- a/Sources/NukeWebP/NukeWebP.swift
+++ b/Sources/NukeWebP/NukeWebP.swift
@@ -28,17 +28,13 @@ public class WebPImageDecoder: ImageDecoding {
         self.decoder = decoder
     }
     
-    public func decode(_ data: Data) -> ImageContainer? {
-        do {
-            return try _queue.sync(execute: {
-                let image = try decoder.decode(data: data)
-                return ImageContainer(image: image, type: .webp, data: data)
-            })
-        } catch {
-            return nil
-        }
+    public func decode(_ data: Data) throws -> ImageContainer {
+        try _queue.sync(execute: {
+            let image = try decoder.decode(data: data)
+            return ImageContainer(image: image, type: .webp, data: data)
+        })
     }
-    
+
     public func decodePartiallyDownloadedData(_ data: Data) -> ImageContainer? {
         do {
             return try _queue.sync(execute: {

--- a/Sources/NukeWebPAdvanced/AdvancedWebPDecoder.swift
+++ b/Sources/NukeWebPAdvanced/AdvancedWebPDecoder.swift
@@ -10,7 +10,7 @@ import AppKit.NSImage
 
 public final class AdvancedWebPDecoder: WebPDecoding {
   
-  private lazy var decoder: WebPDecoder = WebPDecoder()
+  private let decoder = WebPDecoder()
   private let options: WebPDecoderOptions
   
   public init(options: WebPDecoderOptions = .init()) {

--- a/Sources/NukeWebPAdvanced/WebPDecoder.swift
+++ b/Sources/NukeWebPAdvanced/WebPDecoder.swift
@@ -15,16 +15,19 @@ public enum WebPDecodingError: UInt32, Error {
     case unknownError = 9999 // This is an own error to deal with internal problems
 }
 
-public final class WebPDecoder {
+private let _queue = DispatchQueue(label: "com.webp.decoder.advanced", autoreleaseFrequency: .workItem)
+
+public final class WebPDecoder: @unchecked Sendable {
     
     deinit {
-      if idec != nil {
-        WebPIDelete(idec)
-      }
+        _queue.sync(execute: {
+            if idec != nil {
+                WebPIDelete(idec)
+            }
+        })
     }
     
-    public init() {
-    }
+    public init() {}
     
     public func decode(byRGB webPData: Data, options: WebPDecoderOptions) throws -> Data {
         var config = makeConfig(options, .RGB)
@@ -172,35 +175,36 @@ public final class WebPDecoder {
         }
     }
     
-    var idec: OpaquePointer?
+    private var idec: OpaquePointer?
     
     internal func decodei(_ webPData: Data, config: inout WebPDecoderConfig) throws {
-        var mutableWebPData = webPData
-        if idec == nil {
-          idec = WebPINewRGB(MODE_rgbA, nil, 0, 0)
-        }
-        try mutableWebPData.withUnsafeMutableBytes { rawPtr in
-            
-            guard let bindedBasePtr = rawPtr.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
-                throw WebPDecodingError.unknownError
+        try _queue.sync(execute: {
+            var mutableWebPData = webPData
+            if idec == nil {
+                idec = WebPINewRGB(MODE_rgbA, nil, 0, 0)
             }
-            let status = WebPIUpdate(idec, bindedBasePtr, webPData.count)
-            if status != VP8_STATUS_OK && status != VP8_STATUS_SUSPENDED {
-                throw WebPDecodingError.unknownError
+            try mutableWebPData.withUnsafeMutableBytes { rawPtr in
+                guard let bindedBasePtr = rawPtr.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                    throw WebPDecodingError.unknownError
+                }
+                let status = WebPIUpdate(idec, bindedBasePtr, webPData.count)
+                if status != VP8_STATUS_OK && status != VP8_STATUS_SUSPENDED {
+                    throw WebPDecodingError.unknownError
+                }
+                var width: Int32 = 0
+                var height: Int32 = 0
+                var last_y: Int32 = 0
+                var stride: Int32 = 0
+                guard let rgba = WebPIDecGetRGB(idec, &last_y, &width, &height, &stride) else {
+                    throw WebPDecodingError.unknownError
+                }
+                let rgbaSize = stride * last_y
+                let buff = WebPRGBABuffer(rgba: rgba, stride: stride, size: Int(rgbaSize))
+                config.output.u = WebPDecBuffer.Colorspace.RGBA(buff)
+                config.output.height = Int(last_y)
+                config.output.width = Int(width)
             }
-            var width: Int32 = 0
-            var height: Int32 = 0
-            var last_y: Int32 = 0
-            var stride: Int32 = 0
-            guard let rgba = WebPIDecGetRGB(idec, &last_y, &width, &height, &stride) else {
-                throw WebPDecodingError.unknownError
-            }
-            let rgbaSize = stride * last_y
-            let buff = WebPRGBABuffer(rgba: rgba, stride: stride, size: Int(rgbaSize))
-            config.output.u = WebPDecBuffer.Colorspace.RGBA(buff)
-            config.output.height = Int(last_y)
-            config.output.width = Int(width)
-        }
+        })
     }
     
     internal func makeConfig(_ options: WebPDecoderOptions,

--- a/Sources/NukeWebPAdvanced/WebPDecoder.swift
+++ b/Sources/NukeWebPAdvanced/WebPDecoder.swift
@@ -208,7 +208,7 @@ public final class WebPDecoder: @unchecked Sendable {
     }
     
     internal func makeConfig(_ options: WebPDecoderOptions,
-                            _ colorspace: ColorspaceMode) -> WebPDecoderConfig {
+                             _ colorspace: ColorspaceMode) -> WebPDecoderConfig {
         var config = WebPDecoderConfig()
         config.options = options
         config.output.colorspace = colorspace

--- a/Sources/NukeWebPAdvanced/WebPDecoderConfig.swift
+++ b/Sources/NukeWebPAdvanced/WebPDecoderConfig.swift
@@ -1,7 +1,7 @@
 import Foundation
 import libwebp
 
-public struct WebPDecoderConfig: InternalRawRepresentable {
+public struct WebPDecoderConfig: InternalRawRepresentable, Sendable {
     public var input: WebPBitstreamFeatures?  // Immutable bitstream features (optional)
     public var output: WebPDecBuffer          // Output buffer (can point to external mem)
     public var options: WebPDecoderOptions    // Decoding options
@@ -25,8 +25,8 @@ public struct WebPDecoderConfig: InternalRawRepresentable {
     }
 }
 
-public struct WebPBitstreamFeatures: InternalRawRepresentable {
-    public enum Format: Int {
+public struct WebPBitstreamFeatures: InternalRawRepresentable, Sendable {
+    public enum Format: Int, Sendable {
         case undefined = 0
         case lossy
         case lossless
@@ -79,7 +79,7 @@ public struct WebPBitstreamFeatures: InternalRawRepresentable {
 // these two modes:
 // RGBA-4444: [b3 b2 b1 b0 a3 a2 a1 a0], [r3 r2 r1 r0 g3 g2 g1 g0], ...
 // RGB-565: [g2 g1 g0 b4 b3 b2 b1 b0], [r4 r3 r2 r1 r0 g5 g4 g3], ...
-public enum ColorspaceMode: Int {
+public enum ColorspaceMode: Int, Sendable {
     case RGB = 0
     case RGBA = 1
     case BGR = 2
@@ -118,8 +118,8 @@ public enum ColorspaceMode: Int {
     }
 }
 
-public struct WebPDecBuffer: InternalRawRepresentable {
-    public enum Colorspace {
+public struct WebPDecBuffer: InternalRawRepresentable, Sendable {
+    public enum Colorspace: Sendable {
         case RGBA(WebPRGBABuffer)
         case YUVA(WebPYUVABuffer)
 
@@ -191,7 +191,7 @@ public struct WebPDecBuffer: InternalRawRepresentable {
     }
 }
 
-public struct WebPDecoderOptions: InternalRawRepresentable {
+public struct WebPDecoderOptions: InternalRawRepresentable, Sendable {
     public var bypassFiltering: Int // if true, skip the in-loop filtering
 
     public var noFancyUpsampling: Int // if true, use faster pointwise upsampler

--- a/Sources/NukeWebPAdvanced/WebPEncoder.swift
+++ b/Sources/NukeWebPAdvanced/WebPEncoder.swift
@@ -24,7 +24,7 @@ public enum WebPEncodeStatusCode: Int, Error {
     case last                  // list terminator. always last.
 }
 
-public struct WebPEncoder {
+public struct WebPEncoder: Sendable {
     typealias WebPPictureImporter = (UnsafeMutablePointer<WebPPicture>, UnsafeMutablePointer<UInt8>, Int32) -> Int32
 
     public init() {

--- a/Sources/NukeWebPAdvanced/WebPEncoderConfig.swift
+++ b/Sources/NukeWebPAdvanced/WebPEncoderConfig.swift
@@ -21,8 +21,8 @@ extension libwebp.WebPImageHint: ExpressibleByIntegerLiteral {
 
 
 // mapping from libwebp.WebPConfig
-public struct WebPEncoderConfig: InternalRawRepresentable {
-    public enum WebPImageHint: libwebp.WebPImageHint {
+public struct WebPEncoderConfig: InternalRawRepresentable, Sendable {
+    public enum WebPImageHint: libwebp.WebPImageHint, Sendable {
         case `default` = 0
         case picture = 1
         case photo = 2

--- a/Sources/NukeWebPAdvanced/WebPImageInspector.swift
+++ b/Sources/NukeWebPAdvanced/WebPImageInspector.swift
@@ -1,7 +1,7 @@
 import Foundation
 import libwebp
 
-public struct WebPImageInspector {
+public struct WebPImageInspector: Sendable {
 
     public static func inspect(_ webPData: Data) throws -> WebPBitstreamFeatures {
         let cFeature = UnsafeMutablePointer<libwebp.WebPBitstreamFeatures>.allocate(capacity: 1)

--- a/Tests/NukeWebPTests/NukeWebPTests.swift
+++ b/Tests/NukeWebPTests/NukeWebPTests.swift
@@ -1,11 +1,24 @@
 @testable import NukeWebP
 import XCTest
+import NukeWebPAdvanced
 import NukeWebPBasic
 import Nuke
 
 final class NukeWebPTests: XCTestCase {
-    
-    func testExample() throws {
 
+    override func setUp() {
+        ImageDecoderRegistry.shared.clear()
+    }
+
+    func testToEnableBasicWebPDecoder() {
+        WebPImageDecoder.enable(auto: BasicWebPDecoder())
+    }
+
+    func testToEnableAdvancedWebPDecoder() {
+        WebPImageDecoder.enable(closure: {
+            var options = WebPDecoderOptions()
+            options.useThreads = true
+            return AdvancedWebPDecoder(options: options)
+        })
     }
 }


### PR DESCRIPTION
## Why

Follow Nuke updates.

## What

* Update Nuke version to `11.2.1`
* Add Sendable to classes and structs

## How

Wrapped some processing in DispatchQueue to make `BasicWebPDeocder` and `(Advanced)WebPDecoder` conform to `Sendable`.

## TODO

* test if webp images can be decoded